### PR TITLE
build(docker): use a vulnerable docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM node:8-alpine
+FROM node:6-stretch
 
-RUN mkdir /usr/src
 RUN mkdir /usr/src/goof
 RUN mkdir /tmp/extracted_files
 COPY . /usr/src/goof

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goof",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "A vulnerable todo demo application",
   "homepage": "https://snyk.io/",
   "repository": {


### PR DESCRIPTION
* Uses Debian Stretch which has vulnerable system libraries and we can make use of it for the demos
* Uses Node.js 6 so we can also demo the Buffer memory vulnerability with the Docker container