### PR TITLE
Specify platform in Docker Compose so nodejs-goof can run on Apple Silicon (M1/M2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,14 @@ services:
       - goof-mongo
   goof-mongo:
     container_name: goof-mongo
+    platform: linux/amd64
     image: mongo:3
     ports:
       - "27017:27017"
   good-mysql:
     container_name: goof-mysql
     image: mysql:5
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: acme


### PR DESCRIPTION
The Mongo image (mongo:3) and MySQL Image (mysql:5) do not have runtimes compatible with Apple Silicon (M1/M2 Macs). I changed the `docker-compose.yml` file to specify `platform: linux/amd64` for those images. You can see their limited support based on the links to those images on Dockerhub below.

* Dockerhub page for [mongo:3](https://dso.docker.com/images/mongo/digests/sha256:f9b01e368fd95a783a68471930a15c2494d525318ff65a1b408ff3e6bc83e3d4) only has support for `linux/amd64` architecture
* Dockerhub page for [mysql:5](https://dso.docker.com/images/mysql/digests/sha256:444e015ba2ad9fc0884a82cef6c3b15f89db003aef11b55e4daca24f55538cb9) only has support for `linux/amd64` architecture

An alternative workaround is to specify `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before running `docker-compose up -d`, but that would not be beginner friendly and would likely lead to the main application container taking much longer to build. It is easier to just specify the platform here.

It looks like this was previously attempted in #1169 which was strangely reverted in #1294. Judging from that PR, perhaps that was accidental.

Hope this helps. Thanks!