### PR TITLE
feat: add support for redirecting admins to custom dashboards view

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -19,6 +19,19 @@ var fs = require('fs');
 // prototype-pollution
 var _ = require('lodash');
 
+function onLoginSuccessHook(redirectPage, session, username, res) {
+  session.loggedIn = 1
+
+  // Log the login action for audit
+  console.log(`User logged in: ${username}`)
+
+  if (redirectPage) {
+      return res.redirect(redirectPage)
+  } else {
+      return res.redirect('/admin')
+  }
+}
+
 exports.index = function (req, res, next) {
   Todo.
     find({}).


### PR DESCRIPTION
Hi there!

This pull request adds an `onLoginSuccessHook` middleware function to the web app to support a feature in which users can be redirected to their custom dashboard views in the app (or other pages such as account / settings / etc).

I also added a `console.log()` to audit logged-in state for tampering threat model.