### PR TITLE
Fix Docker build by pinning Node.js to v16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:6-stretch
-FROM node:18.13.0
+FROM node:16.20.2
 
 RUN mkdir /usr/src/goof
 RUN mkdir /tmp/extracted_files


### PR DESCRIPTION
### Summary
Docker build fails for the `goof` project because Node.js 18+ rejects the `--openssl-legacy-provider` option, causing the container to exit immediately.

### Changes
- Updated Dockerfile to pin Node.js version to 16.20.2
- Verified that `docker-compose build` and `docker-compose up` succeed locally

### Testing
- `docker-compose build --no-cache` ✅
- `docker-compose up` ✅
- Node.js inside container reports version v16.20.2 ✅

### Notes
- Warnings from MySQL (TIMESTAMP, TLSv1, PID file) are informational and do not affect functionality.
- Docker Compose `version` warning is ignored; no changes required for this PR.

### Issue
Fixes #1290
