### PR TITLE
fix: replace hardcoded secret token with env var or crypto-random fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,8 +80,10 @@ if (app.get('env') == 'development') {
   app.use(errorHandler());
 }
 
-var token = 'SECRET_TOKEN_f8ed84e8f41e4146403dd4a6bbcea5e418d23a9';
-console.log('token: ' + token);
+var token = process.env.SESSION_SECRET || crypto.randomBytes(32).toString('hex');
+if (app.get('env') === 'development') {
+  console.log('Session secret (dev only):', token);
+}
 
 http.createServer(app).listen(app.get('port'), function () {
   console.log('Express server listening on port ' + app.get('port'));


### PR DESCRIPTION
Fixed hardcoded secret token security issue.

**Before:**
```javascript
var token = 'SECRET_TOKEN_f8ed84e8f41e4146403dd4a6bbcea5e418d23a9';
console.log('token: ' + token);
```

**After:**
```javascript
var token = process.env.SESSION_SECRET || crypto.randomBytes(32).toString('hex');
if (app.get('env') === 'development') {
  console.log('Session secret (dev only):', token);
}
```

**What was fixed:**
- Hardcoded secret token was being logged to console on every startup
- Now uses SESSION_SECRET env var, or generates a random 32-byte hex string
- Only logs in development mode to avoid leaking secrets in production

— Sent via @AmSach bot